### PR TITLE
Replace logstash references with slog-syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Attributes will be injected in log payload.
 ```go
 import (
 	"log/syslog"
-	slogsyslog "github.com/samber/slog-logtsash"
+	slogsyslog "github.com/samber/slog-syslog"
 	"golang.org/x/exp/slog"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/samber/slog-logtsash
+module github.com/samber/slog-syslog
 
 go 1.20
 


### PR DESCRIPTION
Hi, thanks for the awesome module!

I came across this error when trying to install the package:

```
go get github.com/samber/slog-syslog
go: downloading github.com/samber/slog-syslog v0.1.0
go: github.com/samber/slog-syslog@v0.1.0: parsing go.mod:
	module declares its path as: github.com/samber/slog-logtsash
	        but was required as: github.com/samber/slog-syslog
```