### PR TITLE
Return receiver in WithGroups method when name is empty

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -97,6 +97,7 @@ func (h *SyslogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 }
 
 func (h *SyslogHandler) WithGroup(name string) slog.Handler {
+	// https://cs.opensource.google/go/x/exp/+/46b07846:slog/handler.go;l=247
 	if name == "" {
 		return h
 	}

--- a/handler.go
+++ b/handler.go
@@ -97,6 +97,10 @@ func (h *SyslogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 }
 
 func (h *SyslogHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+
 	return &SyslogHandler{
 		option: h.option,
 		attrs:  h.attrs,


### PR DESCRIPTION
#4 

Same implementation in log/slog https://cs.opensource.google/go/x/exp/+/46b07846:slog/handler.go;l=247