### PR TITLE
Fix documentation to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ type Option struct {
 	Level slog.Leveler
 
 	// connection to syslog server
-	Writer *syslog.Writer
+	Writer io.Writer
 
 	// optional: customize json payload builder
 	Converter Converter


### PR DESCRIPTION
The type of the `Writer` field was changed from `*syslog.Writer` to `io.Writer` back in commit de8e7b7ced0608c0cd81c4812ecc7d774ada0c16, but the README file still gives the old definition.